### PR TITLE
update for deno 1.8.3

### DIFF
--- a/oak/server.ts
+++ b/oak/server.ts
@@ -1,4 +1,4 @@
-import {Application, Router} from 'https://deno.land/x/oak@v5.3.1/mod.ts'
+import {Application, Router} from 'https://deno.land/x/oak/mod.ts'
 import { staticFileMiddleware } from './staticFileMiddleware.ts';
 
 const app = new Application();

--- a/oak/staticFileMiddleware.ts
+++ b/oak/staticFileMiddleware.ts
@@ -1,6 +1,6 @@
-import {Context, send} from 'https://deno.land/x/oak@v5.3.1/mod.ts'
+import {Context, send, Middleware} from 'https://deno.land/x/oak/mod.ts'
 
-export const staticFileMiddleware = async (ctx: Context, next: Function) => {
+export const staticFileMiddleware: Middleware = async (ctx, next) => {
   const path = `${Deno.cwd()}/public${ctx.request.url.pathname}`;
   
   if (await fileExists(path)) {
@@ -11,7 +11,6 @@ export const staticFileMiddleware = async (ctx: Context, next: Function) => {
     await next();
   }
 }
-
 
 async function fileExists(path: string) {
   try {


### PR DESCRIPTION
removed oak version from imports
changed the staticFileMiddleware function signature so that vscode doesn't complain